### PR TITLE
auto format

### DIFF
--- a/one-sharp/main.rkt
+++ b/one-sharp/main.rkt
@@ -1,6 +1,6 @@
 #lang racket
 (module reader racket
-  (require one-sharp/reader)
+  (require one-sharp/reader one-sharp/unparser)
   (provide read-syntax read get-info)
 
   ;################
@@ -16,4 +16,27 @@
         [(drracket:opt-out-toolbar-buttons)
          ; opt out of all usual DrRacket tool bar buttons
          '(drracket:syncheck debug-tool macro-stepper)]
+        [(drracket:keystrokes)
+         ; #lang's keystroke for formatting text when C-i is pressed
+         ; if parser throws an exception, the same text should be returned
+         `(("c:%" ,(λ (text% event%)
+                     (define lang-lit "#lang")
+                     (define one-sharp-lit "one-sharp")
+                     (define lang-code (send text% get-text))
+                     (define current-pos (send text% get-start-position))
+                     ; formatting the text
+                     ; need to remove #lang line, so let's remove that "properly"
+                     (define removed-lang
+                       (substring (string-trim (substring (string-trim lang-code)
+                                                          (string-length lang-lit)))
+                                  (string-length one-sharp-lit)))
+                     (define formatted-code (format removed-lang))
+                     (define final-code
+                       (if (string=? "" lang-code)
+                           ""
+                           (string-append lang-lit " " one-sharp-lit formatted-code)))
+                     ; now we edit the text% object
+                     (send text% clear)
+                     (send text% insert final-code 0 'same #f)
+                     (send text% set-position current-pos 'same #f #t 'default))))]
         [else default]))))

--- a/one-sharp/main.rkt
+++ b/one-sharp/main.rkt
@@ -36,7 +36,9 @@
                            ""
                            (string-append lang-lit " " one-sharp-lit formatted-code)))
                      ; now we edit the text% object
-                     (send text% clear)
+                     (send text% begin-edit-sequence)
+                     (send text% erase)
                      (send text% insert final-code 0 'same #f)
-                     (send text% set-position current-pos 'same #f #t 'default))))]
+                     (send text% set-position current-pos 'same #f #t 'default)
+                     (send text% end-edit-sequence))))]
         [else default]))))

--- a/one-sharp/parser.rkt
+++ b/one-sharp/parser.rkt
@@ -25,12 +25,14 @@
       (define tok (lex src in))
       (cond
         [(eof? tok) empty]
-        [(unknown? tok) (raise-read-error (format "1sharp programs can't contain the character '~a'" (get-unknown tok))
-                                          src
-                                          (syntax-line tok)
-                                          (syntax-column tok)
-                                          (syntax-position tok)
-                                          (syntax-span tok))]
+        [(unknown? tok) (raise-syntax-error 'bad-syntax
+                                            (format "1sharp programs can't contain the character '~a'" (get-unknown tok))
+                                            (datum->syntax #f tok
+                                                           `(,src
+                                                             ,(syntax-line tok)
+                                                             ,(syntax-column tok)
+                                                             ,(syntax-position tok)
+                                                             ,(syntax-span tok))))]
         [(whitespace? tok) (lexer)]
         [else (cons tok (lexer))])))
   

--- a/one-sharp/parser.rkt
+++ b/one-sharp/parser.rkt
@@ -142,7 +142,7 @@
   (define unknown (open-input-string "1 ## ## s##"))
 
   (check-exn
-   (regexp "the character 's'")
+   (regexp "unexpected character")
    (lambda ()
      (parse-1# #f unknown)))
 

--- a/one-sharp/parser.rkt
+++ b/one-sharp/parser.rkt
@@ -26,8 +26,8 @@
       (cond
         [(eof? tok) empty]
         [(unknown? tok) (raise-syntax-error 'bad-syntax
-                                            (format "1sharp programs can't contain the character '~a'" (get-unknown tok))
-                                            (datum->syntax #f tok
+                                            "found an unexpected character"
+                                            (datum->syntax #f (list->string `(,(get-unknown tok)))
                                                            `(,src
                                                              ,(syntax-line tok)
                                                              ,(syntax-column tok)
@@ -61,7 +61,7 @@
                (define span (- ending-pos starting-pos))
                (cond
                  [(not (< 0 sharps 6)) (raise-syntax-error 'bad-instr
-                                                           (format "A 1sharp instruction '#' count should be in range [1,5], found ~a #s" sharps)
+                                                           (format "A 1sharp instruction's '#' count should be in range [1,5], found ~a #s" sharps)
                                                            (datum->syntax #f (format "~a~a"
                                                                                      (build-string 1s (λ (_) #\1))
                                                                                      (build-string sharps (λ (_) #\#)))

--- a/one-sharp/unparser.rkt
+++ b/one-sharp/unparser.rkt
@@ -1,0 +1,107 @@
+#lang racket
+(require one-sharp/parser)
+(provide (rename-out [unparse-1# unparse]
+                     [format-1# format]))
+
+; Loc is a (list Any Number Number Number Number)
+;;               src line   col    pos    span
+
+; AST is a [Listof (U (instr Number Number Loc) (comment String Loc)))]
+; unparser: AST -> String 
+; produces the code string when given an AST.
+(define (unparse-1# ast)
+  (define (node->string node)
+    (match node
+      [`(instr ,ones ,sharps  ,_) (string-append (build-string ones (λ (_) #\1))
+                                                 (build-string sharps (λ (_) #\#))
+                                                 "\n")] 
+      [`(comment ,cmnt-string ,_) (string-append ";" cmnt-string "\n")]))
+  (define comment? (λ (node) (and (symbol? (car node)) (symbol=? 'comment (car node)))))
+  (define instr? (λ (node) (and (symbol? (car node)) (symbol=? 'instr (car node)))))
+  
+  ; idea is to convert an `instr node as is, but add a '\n' before each comment block
+  ; except for the very first comment block (which is represented by `init-comments`)
+  ; this is so I can manually add a newline before the very first comment or instruction
+  ; the newline is necessary so I can then add a "#lang one-sharp"
+  (define reducer (λ (a b) (string-append b (node->string a))))
+  (define init-comments (foldl reducer "" (takef ast comment?)))
+  
+  ; group-comments : AST -> [Listof (U (instr Number Number Loc) [Listof (comment String Loc)]))] -> 
+  (define (group-comments ast)
+    (match ast
+      ['() '()]
+      [`((comment ,c ,_) . ,rest) `(,(takef ast comment?) . ,(group-comments (dropf ast comment?)))]
+      [`(,instr . ,rest) `(,instr . ,(group-comments rest))]))
+  ; combine, and remove white space from the right of the string
+  (string-trim (string-append
+                "\n"
+                init-comments
+                (foldr (λ (e r) (string-append (if (instr? e) (node->string e)
+                                                   (foldl reducer "\n" e))
+                                               r))
+                       ""
+                       (group-comments (dropf ast comment?)))) #:left? #f))
+
+; uses parser + unparser to format given code
+; format-1#: String -> String
+(define (format-1# code)
+  (with-handlers ([exn:fail:syntax? (λ (_) code)])
+    (unparse-1# (parse #f (open-input-string code)))))
+
+(module+ test
+  (require rackunit one-sharp/parser)
+
+  (define empty-str (parse #f (open-input-string "")))
+  (check-equal? (unparse-1# empty-str) "")
+  
+  (define test-input-port (open-input-string "
+        ;startWithACommentNewLine!
+1
+  1 #   ;1
+1 #### #
+;lastLineNoNewLine!"))
+  (define parsed-test-input-port (parse #f test-input-port))
+  (define expected-code
+    "
+;startWithACommentNewLine!
+11#
+
+;1
+1#####
+
+;lastLineNoNewLine!")
+  (check-equal? (unparse-1# parsed-test-input-port) expected-code)
+
+  ; testing hoisted comments
+  (define comments (open-input-string "
+;comment1
+1
+;comment2
+1
+;comment3
+#
+;comment4
+#
+;comment5"))
+
+  (define exp-code
+    "
+;comment1
+;comment2
+;comment3
+;comment4
+11##
+
+;comment5")
+  (check-equal? (unparse-1# (parse #f comments)) exp-code)
+
+  (define instr (open-input-string "
+1#1###1##1#####1#"))
+  (define exp-instr
+    "
+1#
+1###
+1##
+1#####
+1#")
+  (check-equal? (unparse-1# (parse #f instr)) exp-instr))


### PR DESCRIPTION
Ctrl-% will now auto-format 1#. Auto-format places the cursor close to where it was before, but it can definitely be improved but it'll be kinda annoying to implement.

If parser fails or the text buffer is empty, auto-format should not change the text at all. Else, it will format the code as specified in `unparser.rkt`

Example formatting:

Original:
```
#lang one-sharp
1#####

;##
1#
;test
1#


1#1#
;111####;domment?
;11;dommentyh#
;#####
##
;test
#;howbout
1#####1#1#
;test
1####
;
;x
1#
;test
;hmm
;wow?
;hmmmmmm?
;HEY!
;it worked finally
;p cool
1#####;##
```

After auto-format:
```
#lang one-sharp
1#####

;##
1#

;test
1#
1#

;111####;domment?
;11;dommentyh#
;#####
;test
1####

;howbout
1#####
1#
1#

;test
1####

;
;x
1#

;test
;hmm
;wow?
;hmmmmmm?
;HEY!
;it worked finally
;p cool
1#####

;##
```